### PR TITLE
Add a fallback authentication option

### DIFF
--- a/Classes/User/UserHandler.php
+++ b/Classes/User/UserHandler.php
@@ -98,7 +98,8 @@ class UserHandler
 
 		// Applies only if field is empty in the database
 		if (!empty($mappingEmptyDbFieldName)) {
-			$where .= ' AND ('.$mappingEmptyDbFieldName.' IS NULL OR '.$mappingEmptyDbFieldName.'=\'\') ';
+			$lookupField = $this->config['IDMapping.'][$mappingEmptyDbFieldName];
+			$where .= ' AND ('.$lookupField.' IS NULL OR '.$lookupField.'=\'\') ';
 		}
 
 		// Next line: Don't use "enable_clause", as it will also exclude hidden users, i.e.

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
     }
   ],
   "autoload": {
+    "files": [
+      "sv1/class.tx_shibboleth_sv1.php"
+    ],
     "psr-4": {
       "TrustCnct\\Shibboleth\\": "Classes"
     }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -49,7 +49,7 @@ if (is_array($subtypesArray)) {
 		'quality' => 80,
 		'os' => '',
 		'exec' => '',
-		'className' => 'TrustCnct\\Shibboleth\\tx_shibboleth_sv1',
+		'className' => 'tx_shibboleth_sv1',
 	)
 );
 

--- a/sv1/class.tx_shibboleth_sv1.php
+++ b/sv1/class.tx_shibboleth_sv1.php
@@ -27,8 +27,6 @@
  * Hint: use extdeveval to insert/update function index above.
  */
 
-namespace TrustCnct\Shibboleth;
-
 use TrustCnct\Shibboleth\User\UserHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 


### PR DESCRIPTION
This patch adds a second field to the mapping configuration. It can be used as an alternative identifier in case the first one doesn't match.

Use case: This is very useful when you use the persistent-id (which is unique per system and user) and move the TYPO3 instance to another host. In such a case, the persistent-id won't match and the user will not be recognized.

Note: The persistent-id field needs to be cleared in the database to make the alternative matching work...

The patch was written by @TobCube, not me.
